### PR TITLE
use gunicorn server instead of django test server (as recommended by taiga) #35 #42

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,13 +53,19 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 
 
-RUN echo "LANG=en_US.UTF-8" > /etc/default/locale
-RUN echo "LC_TYPE=en_US.UTF-8" > /etc/default/locale
-RUN echo "LC_MESSAGES=POSIX" >> /etc/default/locale
-RUN echo "LANGUAGE=en" >> /etc/default/locale
+#RUN echo "LANG=en_US.UTF-8" >> /etc/default/locale
+#RUN echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale
+#RUN echo "LC_TYPE=en_US.UTF-8" >> /etc/default/locale
+#RUN echo "LC_MESSAGES=POSIX" >> /etc/default/locale
+#RUN echo "LANGUAGE=en" >> /etc/default/locale
+
+
 
 ENV LANG en_US.UTF-8
 ENV LC_TYPE en_US.UTF-8
+
+
+RUN locale-gen en_US.UTF-8 && locale -a
 
 ENV TAIGA_SSL False
 ENV TAIGA_ENABLE_EMAIL False
@@ -68,7 +74,7 @@ ENV TAIGA_SECRET_KEY "!!!REPLACE-ME-j1598u1J^U*(y251u98u51u5981urf98u2o5uvoiiuzh
 
 RUN python manage.py collectstatic --noinput
 
-RUN locale -a
+
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Version of Nginx to install
 ENV NGINX_VERSION 1.9.7-1~jessie
 
-RUN apt-key adv \
-  --keyserver hkp://pgp.mit.edu:80 \
-  --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+RUN curl -O https://nginx.org/keys/nginx_signing.key && apt-key add ./nginx_signing.key
 
 RUN echo "deb http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list
 
@@ -52,6 +50,9 @@ ENV LANG C
 
 RUN pip install --no-cache-dir -r requirements.txt
 
+
+
+
 RUN echo "LANG=en_US.UTF-8" > /etc/default/locale
 RUN echo "LC_TYPE=en_US.UTF-8" > /etc/default/locale
 RUN echo "LC_MESSAGES=POSIX" >> /etc/default/locale
@@ -80,4 +81,4 @@ VOLUME /usr/src/taiga-back/media
 COPY checkdb.py /checkdb.py
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["gunicorn", "-w 3", "-t 60", "--pythonpath=.", "-b 127.0.0.1:8001", "taiga.wsgi"]

--- a/conf/nginx/taiga.conf
+++ b/conf/nginx/taiga.conf
@@ -21,7 +21,7 @@ server {
         proxy_set_header X-Scheme $scheme;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http://127.0.0.1:8000/api;
+        proxy_pass http://127.0.0.1:8001/api;
         proxy_redirect off;
         proxy_connect_timeout 300;
         proxy_send_timeout 300;
@@ -35,7 +35,7 @@ server {
         proxy_set_header X-Scheme $scheme;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http://127.0.0.1:8000$request_uri;
+        proxy_pass http://127.0.0.1:8001$request_uri;
         proxy_redirect off;
     }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -59,5 +59,5 @@ fi
 # nginx -g "daemon off;"
 service nginx start
 
-# Start Taiga backend Django server
+# Start gunicorn  server
 exec "$@"


### PR DESCRIPTION
This pull request fixes #35, fixes #42  and contains the following changes:
* migrate usage of the django webserver which is not recommended <https://docs.djangoproject.com/en/1.11/intro/tutorial01/#the-development-server> to gunicorn as suggested by tiaga <https://taigaio.github.io/taiga-doc/dist/setup-production.html>
* use the apt-key from the nginx website
By the way: gunicorn feels much faster...