### PR TITLE
fix TLS issue

### DIFF
--- a/conf/nginx/ssl.conf
+++ b/conf/nginx/ssl.conf
@@ -40,7 +40,7 @@ server {
         proxy_set_header X-Scheme $scheme;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_pass http://127.0.0.1:8000$request_uri;
+        proxy_pass https://127.0.0.1:8000$request_uri;
         proxy_redirect off;
     }
 
@@ -54,9 +54,10 @@ server {
         alias /usr/src/taiga-back/media;
     }
 
-    # Events
+
+   # Events
     location /events {
-       proxy_pass http://events:8888/events;
+       proxy_pass http://127.0.0.1:8888/events;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Fix issue when enabling SSL in docker-compose file. Nginx is not configured properly to use API through HTTPS.