### PR TITLE
Add TAIGA_DB_CHECK_ONLY flag, plus fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.5-jessie
 MAINTAINER Benjamin Hutchins <ben@hutchins.co>
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -64,8 +64,6 @@ ENV TAIGA_SSL False
 ENV TAIGA_ENABLE_EMAIL False
 ENV TAIGA_HOSTNAME localhost
 ENV TAIGA_SECRET_KEY "!!!REPLACE-ME-j1598u1J^U*(y251u98u51u5981urf98u2o5uvoiiuzhlit3)!!!"
-
-RUN python manage.py collectstatic --noinput
 
 RUN locale -a
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Use the following environmental variables to generate a `local.py` for [taiga-ba
   - `-e TAIGA_SSL=True` (see `Enabling HTTPS` below)
   - `-e TAIGA_SECRET_KEY` (set this to a random string to configure the `SECRET_KEY` value for taiga-back; defaults to an insecure random string)
   - `-e TAIGA_SKIP_DB_CHECK` (set to skip the database check that attempts to automatically setup initial database)
+  - `-e TAIGA_DB_CHECK_ONLY` (set to stop the container right after initializing the DB)
   - `-e TAIGA_ENABLE_EMAIL=True` (see `Configuring SMTP` below)
 
 *Note*: Database variables are also required, see `Using Database server` below. These are required even when using a container for your database.


### PR DESCRIPTION
Overview of changes:
- Feature: add TAIGA_DB_CHECK_ONLY flag, to optionally allow the image to be used as a DB-initializer-only, e.g. as a kubernetes init container.
- Fix: ensure docker base image is jessie. Default for python 3.5 is now stretch, which made the build fail.
- Fix: handle clean termination of nginx and taiga app. Bash handles the docker signal.
- Enhancement: do not preload static directory at build-time, as that requires you to specfiy some parameters at build time. This closes issue #52

These changes are needed for clean usage inside of a helm chart for taiga, which i based on your image (thank you!).