### PR TITLE
do not enable async notifications automatically when emails are enabled

### DIFF
--- a/docker-settings.py
+++ b/docker-settings.py
@@ -41,7 +41,6 @@ if os.getenv('RABBIT_PORT') is not None and os.getenv('REDIS_PORT') is not None:
 
 if os.getenv('TAIGA_ENABLE_EMAIL').lower() == 'true':
     DEFAULT_FROM_EMAIL = os.getenv('TAIGA_EMAIL_FROM')
-    CHANGE_NOTIFICATIONS_MIN_INTERVAL = 300 # in seconds
 
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 


### PR DESCRIPTION
By default Taiga notifications are sent synchronously, as defined by the value of the setting CHANGE_NOTIFICATIONS_MIN_INTERVAL (0).
It is wrong to make the assumption that if someone enables the SMTP configuration he also enabled the asynchronous mode of the notifications.